### PR TITLE
Add write endpoints to API

### DIFF
--- a/functions/api.js
+++ b/functions/api.js
@@ -1,11 +1,13 @@
 const functions = require("firebase-functions");
 const admin = require("firebase-admin");
 const express = require('express');
+const bodyParser = require('body-parser');
 const cors = require('cors');
 
 // Initialize Express App and allow all origins
 const app = express();
 app.use(cors({ origin: true }));
+app.use(bodyParser.urlencoded({ extended: true }));
 
 // Middleware for checking validity and access of tokens
 const verifyBearer = async (req, res, next) => {
@@ -139,6 +141,159 @@ app.get('/api/v1/team/progress', async (req, res) => {
 		res.status(401).send()
 	}
 })
+
+// Update the user's level
+app.post('/api/v1/progress/level/:levelValue(\\d+)', async (req, res) => {
+	if (req.apiToken != null && req.apiToken.permissions.includes('WP')) {
+		const db = admin.firestore();
+
+		const requesteeProgressRef = db.collection('progress').doc(req.apiToken.owner);
+
+		if (req.params.levelValue) {
+			await requesteeProgressRef.set({
+				level: parseInt(req.params.levelValue)
+			}, {merge: true});
+			res.status(200).send()
+		}else{
+			res.status(400).send()
+		}
+	}else{
+		res.status(401).send()
+	}
+})
+
+// Update progress on a quest
+app.post('/api/v1/progress/quest/:questId(\\d+)', async (req, res) => {
+	if (req.apiToken != null && req.apiToken.permissions.includes('WP')) {
+		const db = admin.firestore();
+
+		const requesteeProgressRef = db.collection('progress').doc(req.apiToken.owner);
+
+		if (req.body && req.params.questId) {
+
+			// Set up an object to update merge with
+			var updateObject = {}
+			if ('complete' in req.body && typeof req.body.complete === 'boolean') { 
+				updateObject.complete = req.body.complete
+				if(req.body.complete) { 
+					updateObject.timeComplete = new Date().getTime() 
+				}else{
+					updateObject.timeComplete = null
+				}
+			}
+
+			await requesteeProgressRef.set({
+				quests: {[req.params.questId]: updateObject}
+			}, {merge: true});
+			res.status(200).send()
+		}else{
+			res.status(400).send()
+		}
+	}else{
+		res.status(401).send()
+	}
+})
+
+// Update progress on a quest objective
+app.post('/api/v1/progress/quest/objective/:objectiveId(\\d+)', async (req, res) => {
+	if (req.apiToken != null && req.apiToken.permissions.includes('WP')) {
+		const db = admin.firestore();
+
+		const requesteeProgressRef = db.collection('progress').doc(req.apiToken.owner);
+
+		if (req.body && req.params.objectiveId) {
+
+			// Set up an object to update merge with
+			var updateObject = {}
+			// 'have' value
+			if ('have' in req.body && typeof req.body.have === 'number') { updateObject.have = req.body.have }
+			if ('complete' in req.body && typeof req.body.complete === 'boolean') { 
+				updateObject.complete = req.body.complete
+				if(req.body.complete) { 
+					updateObject.timeComplete = new Date().getTime() 
+				}else{
+					updateObject.timeComplete = null
+				}
+			}
+
+			await requesteeProgressRef.set({
+				objectives: {[req.params.objectiveId]: updateObject}
+			}, {merge: true});
+			res.status(200).send()
+		}else{
+			res.status(400).send()
+		}
+	}else{
+		res.status(401).send()
+	}
+})
+
+// Update progress on a hideout objective
+app.post('/api/v1/progress/hideout/:hideoutId(\\d+)', async (req, res) => {
+	if (req.apiToken != null && req.apiToken.permissions.includes('WP')) {
+		const db = admin.firestore();
+
+		const requesteeProgressRef = db.collection('progress').doc(req.apiToken.owner);
+
+		if (req.body && req.params.hideoutId) {
+
+			// Set up an object to update merge with
+			var updateObject = {}
+			if ('complete' in req.body && typeof req.body.complete === 'boolean') { 
+				updateObject.complete = req.body.complete
+				if(req.body.complete) { 
+					updateObject.timeComplete = new Date().getTime() 
+				}else{
+					updateObject.timeComplete = null
+				}
+			}
+
+			await requesteeProgressRef.set({
+				quests: {[req.params.hideoutId]: updateObject}
+			}, {merge: true});
+			res.status(200).send()
+		}else{
+			res.status(400).send()
+		}
+	}else{
+		res.status(401).send()
+	}
+})
+
+// Update progress on a hideout objective
+app.post('/api/v1/progress/hideout/objective/:objectiveId(\\d+)', async (req, res) => {
+	if (req.apiToken != null && req.apiToken.permissions.includes('WP')) {
+		const db = admin.firestore();
+
+		const requesteeProgressRef = db.collection('progress').doc(req.apiToken.owner);
+
+		if (req.body && req.params.objectiveId) {
+
+			// Set up an object to update merge with
+			var updateObject = {}
+			// 'have' value
+			if ('have' in req.body && typeof req.body.have === 'number') { updateObject.have = req.body.have }
+			if ('complete' in req.body && typeof req.body.complete === 'boolean') { 
+				updateObject.complete = req.body.complete
+				if(req.body.complete) { 
+					updateObject.timeComplete = new Date().getTime() 
+				}else{
+					updateObject.timeComplete = null
+				}
+			}
+
+			await requesteeProgressRef.set({
+				hideoutObjectives: {[req.params.objectiveId]: updateObject}
+			}, {merge: true});
+			res.status(200).send()
+		}else{
+			res.status(400).send()
+		}
+	}else{
+		res.status(401).send()
+	}
+})
+
 
 // Export the express app as a cloud function
 exports.default = functions.https.onRequest(app)

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "body-parser": "^1.19.0",
         "firebase-admin": "^9.2.0",
         "firebase-functions": "^3.11.0",
         "uid-generator": "^2.0.0"

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,6 +13,7 @@
   },
   "main": "index.js",
   "dependencies": {
+    "body-parser": "^1.19.0",
     "firebase-admin": "^9.2.0",
     "firebase-functions": "^3.11.0",
     "uid-generator": "^2.0.0"

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -767,6 +767,10 @@
           'TP': {
             title: 'Get Team Progression',
             description: 'Allows access to read a virtual copy of your team\'s progress, including display names, quest, and hideout progress'
+          },
+          'WP': {
+            title: 'Write Progression',
+            description: 'Allows access to update your TarkovTracker progress data on your behalf'
           }
         },
 


### PR DESCRIPTION
Adding endpoints to update quests, hideout modules, quest and hideout objectives, and player level

`POST /api/v1/progress/level/:levelNumber` with no body required

`POST /api/v1/progress/quest/:questId` with a JSON object that contains `complete`

`POST /api/v1/progress/hideout/:hideoutId` with a JSON object that contains `complete`

`POST /api/v1/progress/quest/objective/:objectiveId` with a JSON object that contains `complete` and/or `have`

`POST /api/v1/progress/hideout/objective/:objectiveId` with a JSON object that contains `complete` and/or `have`

Resolves #9 