### PR TITLE
Added Trader reputation stat cards to Dashboard and added option in S…

### DIFF
--- a/src/store/modules/progress.js
+++ b/src/store/modules/progress.js
@@ -10,6 +10,7 @@ const getDefaultState = () => {
     shareName: null,
     dataVersion: 1,
     level: 71,
+    gameEdition: 3,
   }
 }
 

--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -1,6 +1,7 @@
 import questData from '../tarkovdata/quests.json'
 import hideoutData from '../tarkovdata/hideout.json'
 import itemData from '../tarkovdata/items.en.json'
+import traderData from '../tarkovdata/traders.json'
 
 export default {
   data() {
@@ -8,6 +9,7 @@ export default {
       questDataDefault: questData, // Imports the quest data from questData.json
       hideoutDataDefault: hideoutData, // Imports the hideout data from hideoutData.json
       itemDataDefault: itemData, // Imports the item data from items.en.json
+      traderDataDefault: traderData, // Imports the trader data from traders.json
     }
   },
   methods: {

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -611,6 +611,34 @@
         sm="12"
       >
         <material-card
+          icon="mdi-brightness-6"
+          icon-small
+          title="Game Edition"
+          color="info"
+        >
+          <v-card-text>
+            <p>Additional data may be computed from this information (e.g. trader reputation).</p>
+            <v-select
+              v-model="selectedGameEdition"
+              :items="gameEditions"
+              label="Select game edition"
+              item-text="title"
+              item-value="value"
+              color="white"
+              item-color="white"
+              dense
+              outlined
+            ></v-select>
+          </v-card-text>
+        </material-card>
+      </v-col>
+      <v-col
+        class="xs"
+        xl="4"
+        md="6"
+        sm="12"
+      >
+        <material-card
           icon="mdi-eye"
           icon-small
           title="Streamer Mode"
@@ -812,6 +840,12 @@
             value: 'actions',
           },
         ],
+        gameEditions: [
+          { title: 'Standard Edition', value: 0 },
+          { title: 'Left Behind Edition', value: 1 },
+          { title: 'Prepare for Escape Edition', value: 2 },
+          { title: 'Edge of Darkness Limited Edition', value: 3 },
+        ],
         fontOptions: [
           { title: 'Share Tech Mono', value: 0 },
           { title: 'Roboto', value: 1 },
@@ -857,6 +891,14 @@
       },
       tokenCreateEnabled: function () {
         return (this.apiTokenNote.length > 0 && this.apiSelectedPermissions.length > 0)
+      },
+      selectedGameEdition: {
+        get () {
+          return this.$store.copy('progress/gameEdition') || 3
+        },
+        set (value) {
+          this.$store.set('progress/gameEdition', value)
+        }
       },
       selectedFont: {
         get () {


### PR DESCRIPTION
In the end, the stat cards don't look all that bad. They definitely convey the information way better than the graph I tried originally. I also added Game edition selection in settings which defaults to EOD. It could use some enum in the near future instead of magic numbers.

![image](https://user-images.githubusercontent.com/5736517/126066183-4b96fa2e-4d02-4a42-8061-f57fa17996a3.png)

I do think that as the number of stats on the dashboard increases, it might be wise to put multiple of them into a single card (with a slighly adjusted design). Something like:

Eliminations:
PMC: 15/220
Scavs: 79/380

Items:
Find in raid Items: 55/200
Handover Ttems: 20/42
Quest Items: 10/233

Quests:
Quests per day: 4
Quest EXP: 460,200
...etc...

But that's just an idea for another day.