### PR TITLE
Hide quests blocked by failed prequisites

### DIFF
--- a/src/components/QuestRow.vue
+++ b/src/components/QuestRow.vue
@@ -187,6 +187,17 @@
               <v-icon>mdi-replay</v-icon>
             </v-btn>
           </span>
+          <span v-else-if="pageType === 'locked' && myselfQuestAvailable(questDetails) === -2">
+            <v-btn
+              disabled
+              large
+              class="warning"
+              elevation="2"
+            >
+              <v-icon>mdi-fast-forward</v-icon>
+            </v-btn>
+            <div>Quest unavailable</div>
+          </span>        
         </v-col>
       </v-row>
     </v-container>
@@ -217,7 +228,7 @@
           })
         }, this)
         return availability
-      }
+      },
     },
     methods: {
       teamBadgeClass (availability) {

--- a/src/components/QuestRow.vue
+++ b/src/components/QuestRow.vue
@@ -180,7 +180,11 @@
             color="secondary"
             width="fit-content"
           >
-            <span class="text-center">This quest was marked was marked as failed via completion of an alternative.</span>
+            <span class="text-center">This quest was marked was marked as failed via completion of 
+              <span v-for="alternative in questDetails.alternatives">
+                <quest-link :quest-id="alternative" v-if="$store.copy('progress/quest_failed', alternative) === false" />
+              </span>
+            </span>
           </v-alert>
         </v-col>
       </v-row>

--- a/src/components/QuestRow.vue
+++ b/src/components/QuestRow.vue
@@ -73,32 +73,6 @@
               <span>Not required to achieve Kappa</span>
             </v-tooltip>
           </div>
-          <div
-            v-if="typeof questDetails.alternatives !== 'undefined' && questDetails.alternatives.length > 0"
-          >
-            <v-tooltip top>
-              <template v-slot:activator="{ on, attrs }">
-                <v-chip
-                  class="mt-1 font-weight-bold"
-                  x-small
-                  color="info"
-                  v-bind="attrs"
-                  v-on="on"
-                >
-                  ALTERNATIVES
-                </v-chip>
-              </template>
-              <span>
-                Complete one of:
-                <div
-                  v-for="(title, index) in calculateAlternatives(questDetails)"
-                  :key="index"
-                >
-                  <b>{{ title }}</b>
-                </div>
-              </span>
-            </v-tooltip>
-          </div>
           <span v-if="typeof availability !== 'undefined' && availability.length > 1">
             <v-tooltip top>
               <template v-slot:activator="{ on, attrs }">
@@ -186,18 +160,98 @@
             >
               <v-icon>mdi-replay</v-icon>
             </v-btn>
-          </span>
-          <span v-else-if="pageType === 'locked' && myselfQuestAvailable(questDetails) === -2">
-            <v-btn
-              disabled
-              large
-              class="warning"
-              elevation="2"
-            >
-              <v-icon>mdi-fast-forward</v-icon>
-            </v-btn>
-            <div>Quest unavailable</div>
-          </span>        
+          </span>      
+        </v-col>
+      </v-row>
+      <v-row
+        align="center"
+        no-gutters
+        v-if="$store.copy('progress/quest_failed', questDetails.id) === true"
+      >
+        <v-col
+          cols="12"
+          align="center"
+        >
+          <v-alert
+            dense
+            outlined
+            type="info"
+            class="text-caption mx-a"
+            color="secondary"
+            width="fit-content"
+          >
+            <span class="text-center">This quest was marked was marked as failed via completion of an alternative.</span>
+          </v-alert>
+        </v-col>
+      </v-row>
+      <v-row
+        align="center"
+        no-gutters
+        v-if="pageType === 'available' && typeof questDetails.alternatives !== 'undefined' && questDetails.alternatives.length > 0"
+      >
+        <v-col
+          cols="12"
+          align="center"
+        >
+          <v-alert
+            dense
+            outlined
+            type="info"
+            class="text-caption mx-a"
+            color="secondary"
+            width="fit-content"
+          >
+            <span class="text-center">Fails alternative quests:
+              <span v-for="alternative in questDetails.alternatives">
+                <quest-link :quest-id="alternative" />
+              </span>
+            </span>
+          </v-alert>
+        </v-col>
+      </v-row>
+      <v-row
+        align="center"
+        no-gutters
+        v-if="pageType === 'locked' && myselfQuestAvailable(questDetails) === -2"
+      >
+        <v-col
+          cols="12"
+          align="center"
+        >
+          <v-alert
+            dense
+            outlined
+            type="error"
+            class="text-caption mx-a"
+            width="fit-content"
+          >
+            <span class="text-caption">Alternative path taken. Quest blocked.</span>
+          </v-alert>
+        </v-col>
+      </v-row>
+      <v-row
+        align="center"
+        no-gutters
+        v-if="pageType === 'completed' && typeof questDetails.alternatives !== 'undefined' && questDetails.alternatives.length > 0"
+      >
+        <v-col
+          cols="12"
+          align="center"
+        >
+          <v-alert
+            dense
+            outlined
+            type="info"
+            class="text-caption mx-a"
+            color="secondary"
+            width="fit-content"
+          >
+            <span class="text-center">Uncomplete will also reset alternative quests:
+              <span v-for="alternative in questDetails.alternatives">
+                <quest-link :quest-id="alternative" />
+              </span>
+            </span>
+          </v-alert>
         </v-col>
       </v-row>
     </v-container>

--- a/src/store/modules/progress.js
+++ b/src/store/modules/progress.js
@@ -291,6 +291,14 @@ const getters = {
     }
   },
 
+  quest_complete_not_failed: (state) => (id) => {
+    if (state && 'quests' in state && id in state.quests) {
+      return state.quests[id].completed && !state.quests[id].failed
+    } else {
+      return false
+    }
+  },
+
   quest_failed: (state) => (id) => {
     if (state && 'quests' in state && id in state.quests && 'failed' in state.quests[id]) {
       return state.quests[id].failed

--- a/src/store/modules/progress.js
+++ b/src/store/modules/progress.js
@@ -291,6 +291,14 @@ const getters = {
     }
   },
 
+  quest_failed: (state) => (id) => {
+    if (state && 'quests' in state && id in state.quests && 'failed' in state.quests[id]) {
+      return state.quests[id].failed
+    } else {
+      return false
+    }
+  },
+
   objective_complete: (state) => (id) => {
     if (state && 'objectives' in state && id in state.objectives && 'complete' in state.objectives[id]) {
       return state.objectives[id].complete

--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -233,7 +233,8 @@ export default {
           var oneOf = false
           if (Array.isArray(quest.require.quests[x])) {
             for (var i = quest.require.quests[x].length - 1; i >= 0; i--) {
-              if (progressStore.copy('progress/quest_complete', quest.require.quests[x][i]) === true) {
+              if (progressStore.copy('progress/quest_complete', quest.require.quests[x][i]) === true &&
+                  progressStore.copy('progress/quest_failed', quest.require.quests[x][i]) != true) {
                 oneOf = true
               }
             }
@@ -243,8 +244,14 @@ export default {
               return -1
             }
           }
-          // If the prereq isn't completed, then we are locked
-          if (!oneOf && !progressStore.copy('progress/quest_complete', quest.require.quests[x])) {
+          // If the prereq isn't completed & not failed, then we are locked
+          if (
+              !oneOf && 
+              (
+                !progressStore.copy('progress/quest_complete', quest.require.quests[x]) || 
+                progressStore.copy('progress/quest_failed', quest.require.quests[x])
+              )
+            ) {
             return -1
           }
         }

--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -92,7 +92,14 @@ export default {
       })
     },
     QuestUncomplete(quest) {
-      this.$store.set('progress/uncomplete_quest', quest.id)
+      this.$store.set('progress/unfail_quest', quest.id)
+      // If there are any alternative quests, mark them as not complete, not failed
+      if (quest.alternatives) {
+        // For each alternative
+        quest.alternatives.forEach((questId) => {
+          this.$store.set('progress/unfail_quest', questId)
+        }, this)
+      }
 
       this.$analytics.logEvent('quest_uncomplete', {
         event_category: 'Progression',

--- a/src/views/AllQuests.vue
+++ b/src/views/AllQuests.vue
@@ -752,10 +752,10 @@
           case 1: // The 'Locked' view (show locked specifically for yourself)
             if ( this.showAnyFromTeam ) {
               // Were viewing ourself, normal use case, show everything available currently
-              quests = quests.filter(quest => this.$root.questAvailability[quest.id][0] == -1)
+              quests = quests.filter(quest => this.$root.questAvailability[quest.id][0] <= -1)
             }else{
               // We specifically want to see what another teammate has available
-              quests = quests.filter(quest => this.$root.questAvailability[quest.id][this.activeTeamTab - 1] == -1)
+              quests = quests.filter(quest => this.$root.questAvailability[quest.id][this.activeTeamTab - 1] <= -1)
             }
             break;
 


### PR DESCRIPTION
This makes the UI do more in terms of preventing users from completing optional quests which they didn't actually complete due to failed prerequisites (ie Chemical Part 4/Out of Curiosity/Big Customer)

TODO: Explain to the user when completing an quest with alternatives, that the others will be marked as failed, like in the game.