### PR TITLE
Just force users to select which path first for alternatives

### DIFF
--- a/src/components/QuestRow.vue
+++ b/src/components/QuestRow.vue
@@ -229,7 +229,7 @@
             class="text-caption mx-a"
             width="fit-content"
           >
-            <span class="text-caption">Alternative path taken. Quest blocked.</span>
+            <span class="text-caption">Alternative path taken, or required path not selected. Quest blocked.</span>
           </v-alert>
         </v-col>
       </v-row>

--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -254,8 +254,8 @@ export default {
               }
             }
 
-            if (!oneOfNotFailed) {
-              // All of the optional array of prereqs were failed, so were blocked
+            if (!oneOfNotFailed || !oneOf) {
+              // We haven't selected a path
               return -2
             }
 


### PR DESCRIPTION
Just making it simple and blocking the ability to skip to them entirely until they select one of the previous optionals.

If BSG ever adds longer chains after the optionals, this logic will need to be made smarter, but works for the current alternative cases.