### PR TITLE
Quest detail enhancement - Quest navigation buttons (Resolves #111)

### DIFF
--- a/src/components/QuestRow.vue
+++ b/src/components/QuestRow.vue
@@ -132,35 +132,56 @@
           class="align-md-end"
         >
           <span v-if="pageType === 'available' && myselfQuestAvailable(questDetails) === 0">
-            <v-btn
-              large
-              class="success"
-              elevation="2"
-              @click="localQuestComplete(questDetails)"
-            >
-              <v-icon>mdi-check-all</v-icon>
-            </v-btn>
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn
+                  v-bind="attrs"
+                  v-on="on"
+                  large
+                  class="warning"
+                  elevation="2"
+                  @click="localQuestComplete(questDetails)"
+                >
+                  <v-icon>mdi-check-all</v-icon>
+                </v-btn>
+              </template>
+              <span>Complete this quest</span>
+            </v-tooltip>
           </span>
           <span v-else-if="pageType === 'locked' && myselfQuestAvailable(questDetails) === -1">
-            <v-btn
-              large
-              class="warning"
-              elevation="2"
-              @click="localQuestSkip(questDetails)"
-            >
-              <v-icon>mdi-fast-forward</v-icon>
-            </v-btn>
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn
+                  v-bind="attrs"
+                  v-on="on"
+                  large
+                  class="warning"
+                  elevation="2"
+                  @click="localQuestComplete(questDetails)"
+                >
+                  <v-icon>mdi-fast-forward</v-icon>
+                </v-btn>
+              </template>
+              <span>Jump to this quest (Complete all prerequisite quests)</span>
+            </v-tooltip>
           </span>
           <span v-else-if="pageType === 'completed' && myselfQuestAvailable(questDetails) === 1">
-            <v-btn
-              large
-              class="error"
-              elevation="2"
-              @click="localQuestUncomplete(questDetails)"
-            >
-              <v-icon>mdi-replay</v-icon>
-            </v-btn>
-          </span>      
+            <v-tooltip bottom>
+              <template v-slot:activator="{ on, attrs }">
+                <v-btn
+                  v-bind="attrs"
+                  v-on="on"
+                  large
+                  class="warning"
+                  elevation="2"
+                  @click="localQuestUncomplete(questDetails)"
+                >
+                  <v-icon>mdi-replay</v-icon>
+                </v-btn>
+              </template>
+              <span>Undo this quest</span>
+            </v-tooltip>
+          </span>
         </v-col>
       </v-row>
       <v-row
@@ -180,7 +201,7 @@
             color="secondary"
             width="fit-content"
           >
-            <span class="text-center">This quest was marked was marked as failed via completion of 
+            <span class="text-center">This quest was marked as failed via completion of
               <span v-for="alternative in questDetails.alternatives">
                 <quest-link :quest-id="alternative" v-if="$store.copy('progress/quest_failed', alternative) === false" />
               </span>

--- a/src/layouts/default/widgets/Search.vue
+++ b/src/layouts/default/widgets/Search.vue
@@ -6,6 +6,7 @@
     label="Search"
     style="max-width:300px"
     @keydown.enter="searchSite"
+    @change="searchSite"
   >
     <template
       v-if="$vuetify.breakpoint.mdAndUp"

--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -116,7 +116,6 @@ export default {
       var beforeCount = this.$store.copy('progress/quests_array').filter(x => x.complete).length
 
       var unlockedList = this.calculateUnlockedList(quest, this.$store)
-
       for (var i = unlockedList.length - 1; i >= 0; i--) {
         this.CompleteQuest(unlockedList[i])
       }
@@ -192,7 +191,6 @@ export default {
             unlockSet = new Set([...unlockSet, requiredQuestId, ...this.calculateUnlockedListRecursive(requiredQuestId)])
           }, this)
         }
-
         return [...unlockSet]
       //}
       //catch(err) {
@@ -264,7 +262,7 @@ export default {
               return -1
             }
           }else{
-            
+
             if ( progressStore.copy('progress/quest_failed', quest.require.quests[x]) ) {
               // If a prereq is failed, the quest is blocked
               return -2

--- a/src/views/QuestInfo.vue
+++ b/src/views/QuestInfo.vue
@@ -19,8 +19,66 @@
                   <div class="font-weight-bold">
                     Quick Facts:
                   </div>
-                  <v-divider />
                 </v-col>
+                <v-col>
+                  <v-tooltip bottom v-if="myselfQuestAvailable(thisQuest) === -1">
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        v-bind="attrs"
+                        v-on="on"
+                        absolute
+                        top
+                        right
+                        large
+                        class="warning"
+                        elevation="2"
+                        @click="localQuestSkip(thisQuest)"
+                      >
+                        <v-icon>mdi-fast-forward</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>Jump to this quest (Complete all prerequisite quests)</span>
+                  </v-tooltip>
+                  <v-tooltip bottom v-if="myselfQuestAvailable(thisQuest) === 0">
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        v-bind="attrs"
+                        v-on="on"
+                        absolute
+                        top
+                        right
+                        large
+                        class="warning"
+                        elevation="2"
+                        @click="localQuestComplete(thisQuest)"
+                      >
+                        <v-icon>mdi-check-all</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>Complete this quest</span>
+                  </v-tooltip>
+                  <v-tooltip bottom v-if="myselfQuestAvailable(thisQuest) === 1">
+                    <template v-slot:activator="{ on, attrs }">
+                      <v-btn
+                        v-bind="attrs"
+                        v-on="on"
+                        absolute
+                        top
+                        right
+                        large
+                        class="warning"
+                        elevation="2"
+                        @click="localQuestUncomplete(thisQuest)"
+                      >
+                        <v-icon>mdi-replay</v-icon>
+                      </v-btn>
+                    </template>
+                    <span>Undo this quest</span>
+                  </v-tooltip>
+                </v-col>
+              </v-row>
+              <v-row>
+                <v-divider />
               </v-row>
               <v-row>
                 <v-col
@@ -253,6 +311,18 @@
       ],
     },
     methods: {
+      localQuestComplete (quest) {
+        // Call the common mixin complete quest
+        this.CompleteQuest(quest)
+      },
+      localQuestSkip (quest) {
+        // Call the common mixin skip to quest
+        this.QuestSkip(quest)
+      },
+      localQuestUncomplete (quest) {
+        // Call the common mixin uncomplete quest
+        this.QuestUncomplete(quest)
+      },
     },
   }
 </script>


### PR DESCRIPTION
1) Added Buttons to navigate quests to Quest detail (same functionality as in the quest list view. Also added tooltips to both places to better describe what the buttons do).

![image](https://user-images.githubusercontent.com/5736517/127649051-beb67559-321f-49a2-b2d7-6b97c88bc5cc.png)

2) Sligthly changed behaviour of the Search bar at the top. Clicking a quest from the available list directly redirects you to it, you don't have to click Enter or the Search icon anymore.