### PR TITLE
Increase the maximum team size default to 10

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -49,7 +49,7 @@ exports.createTeam = functions.https.onCall( async (data, context) => {
 	myTeamRef.set({
 		owner: context.auth.uid,
 		password: password,
-		maximumMembers: systemDoc.data()?.teamMax || 5,
+		maximumMembers: systemDoc.data()?.teamMax || 10,
 		members: [context.auth.uid],
 		createdAt: admin.firestore.FieldValue.serverTimestamp()
 	})


### PR DESCRIPTION
Will require people to re-create their teams unless I did a bunch of edits to teams. I could do that in the future if people had a problem recreating, but would prefer just to do the easy thing.