### PR TITLE
Set quest levelAvailability true if the quest has no level requirement set

### DIFF
--- a/src/trackerCommonState.js
+++ b/src/trackerCommonState.js
@@ -152,7 +152,10 @@ export default {
         levelAvailability[quest.id] = {}
         this.team.forEach((member, teamIndex) => {
           // If were not a hidden teammate, and were not a teammate with teammates off
-          levelAvailability[quest.id][teamIndex] = (member.store.copy('progress/level') || 71) >= quest.require.level ? true : false
+          // a quest should be available if it has no level requirement set
+          levelAvailability[quest.id][teamIndex] = (
+              quest.require.level === undefined ||
+            ((member.store.copy('progress/level') || 71) >= quest.require.level)) ? true : false
         }, this)
       }, this)
       return levelAvailability


### PR DESCRIPTION
Hey!
I am using the website (and liking it a lot) and found an issue with some quests not showing up on the site even though I can see them in-game.
This occurs when a quest has no level requirement set (in quests.json, like in the case of "quest.id=196") and the "Hide Quests Above Level" filter is turned on.
The problematic filter seems to be this:
`(member.store.copy('progress/level') || 71) >= quest.require.level`
`(number >= undefined) => false`

I made this fix. Hope you like it.
(ps.: Formatting might be off, I don't know this repo's style yet.)
(edit1: Verified in local environment.)