### PR TITLE
Add QR code dialog for API tokens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "firebase": "^8.9.1",
         "firebaseui": "^5.0.0",
         "moment": "^2.29.1",
+        "qrcode.vue": "^1.7.0",
         "vue": "^2.6.14",
         "vue-meta": "^2.3.3",
         "vue-router": "^3.5.2",
@@ -14226,6 +14227,14 @@
       "engines": {
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qrcode.vue": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
+      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
+      "peerDependencies": {
+        "vue": "^2.0.0"
       }
     },
     "node_modules/qs": {
@@ -30656,6 +30665,12 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
+    },
+    "qrcode.vue": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/qrcode.vue/-/qrcode.vue-1.7.0.tgz",
+      "integrity": "sha512-R7t6Y3fDDtcU7L4rtqwGUDP9xD64gJhIwpfjhRCTKmBoYF6SS49PIJHRJ048cse6OI7iwTwgyy2C46N9Ygoc6g==",
+      "requires": {}
     },
     "qs": {
       "version": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "firebase": "^8.9.1",
     "firebaseui": "^5.0.0",
     "moment": "^2.29.1",
+    "qrcode.vue": "^1.7.0",
     "vue": "^2.6.14",
     "vue-meta": "^2.3.3",
     "vue-router": "^3.5.2",

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -449,10 +449,32 @@
                       outlined
                       elevation="2"
                       small
+                      class="ma-1"
                       @click="copyToClipboard(item.token)"
                     >
                       <v-icon>mdi-clipboard-file-outline</v-icon>
                     </v-btn>
+                    <v-dialog
+                      v-model="dialog"
+                      width="200"
+                    >
+                      <template v-slot:activator="{ on, attrs }">
+                        <v-btn
+                          outlined
+                          elevation="2"
+                          small
+                          class="ma-1"
+                          v-bind="attrs"
+                          v-on="on"
+                        >
+                          <v-icon>mdi-qrcode</v-icon>
+                        </v-btn>
+                      </template>
+
+                      <v-card>
+                        <QrcodeVue :value="item.token" level="H" :size="200" render-as="svg" background="#121212" foreground="#ffffff" />
+                      </v-card>
+                    </v-dialog>
                 </template>
                 <template v-slot:item.createdAt="{ item }">
                     <span class="font-weight-bold">
@@ -760,10 +782,12 @@
 <script>
   import moment from 'moment';
   import hideoutFunctions from '../functions/hideoutFunctions';
+  import QrcodeVue from 'qrcode.vue'
 
   export default {
     name: 'SettingsView',
     components: {
+      QrcodeVue
     },
     data () {
       return {


### PR DESCRIPTION
Allows external tools like The Hideout app to utilize TarkovTracker API tokens more easily