### PR TITLE
Fix level tracker index going out of bounds

### DIFF
--- a/src/layouts/default/widgets/PlayerLevel.vue
+++ b/src/layouts/default/widgets/PlayerLevel.vue
@@ -22,7 +22,7 @@
         <v-btn
           icon
           small
-          @click="changeLevel(1)"
+          @click="incrementLevel()"
         >
           <v-icon class="ma-0">
             mdi-chevron-up
@@ -33,7 +33,7 @@
         <v-btn
           icon
           small
-          @click="changeLevel(-1)"
+          @click="decrementLevel()"
         >
           <v-icon class="ma-0">
             mdi-chevron-down
@@ -57,6 +57,9 @@
 
     computed: {
       levelGroup: function () {
+        if(!this.$root.levelDataDefault[this.selfLevel]) {
+          this.selfLevel = 71
+        }
         return this.$root.levelDataDefault[this.selfLevel].group
       },
 
@@ -66,7 +69,7 @@
 
       selfLevel: {
         get () {
-          return this.$store.copy('progress/level') || 71
+          return this.$store.copy('progress/level')
         },
         set (value) {
           this.$store.set('progress/level', value)
@@ -79,9 +82,21 @@
     },
 
     methods: {
-      changeLevel(change) {
-        this.selfLevel += change
-      }
+      incrementLevel() {
+        if(!this.$root.levelDataDefault[this.selfLevel + 1]) {
+          this.selfLevel = 1
+        } else {
+          this.selfLevel += 1
+        }
+      },
+
+      decrementLevel() {
+        if(!this.$root.levelDataDefault[this.selfLevel - 1]) {
+          this.selfLevel = Object.keys(this.$root.levelDataDefault).pop()
+        } else {
+          this.selfLevel -= 1
+        }
+      },
     },
   }
 </script>


### PR DESCRIPTION
Fixes #199.

Assumptions: 
Counter should wrap to the max value if decremented while at the min value.
Counter should wrap to the min value if incremented while at the max value.
New users should still start at 71.

This also fixes the issue for users who are in a broken state already.

There are a lot of ways to implement this so no worries if you would rather implement it some other way.