### PR TITLE
Quests are now locked if player is below quest level

### DIFF
--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -225,7 +225,7 @@ export default {
         return 1
       }
       // If the player level is below the required quest level, then the quest is not available
-      if(progressStore.get("progress/level") < quest.require.level){
+      if(progressStore.get("progress/level") < quest.require.level) {
         return -1
       }
       // Check each of the prerequisites to see if this quest is unlocked

--- a/src/trackerGlobalMixin.js
+++ b/src/trackerGlobalMixin.js
@@ -224,6 +224,10 @@ export default {
       if (progressStore.copy('progress/quest_complete', quest.id)) {
         return 1
       }
+      // If the player level is below the required quest level, then the quest is not available
+      if(progressStore.get("progress/level") < quest.require.level){
+        return -1
+      }
       // Check each of the prerequisites to see if this quest is unlocked
       if (quest.require.quests) {
         // For each prerequisite


### PR DESCRIPTION
This enhancement makes it so that quests are no longer available if the player level on the left side of the screen is below the quest level.