### PR TITLE
fix(item-card): unfilled image height

### DIFF
--- a/tarkov-tracker/src/components/neededitems/NeededItemCard.vue
+++ b/tarkov-tracker/src/components/neededitems/NeededItemCard.vue
@@ -1,12 +1,9 @@
 <template>
   <v-col v-if="showItemFilter" cols="12" sm="6" md="4" lg="3" xl="2">
     <KeepAlive>
-      <v-lazy
-:options="{
-  threshold: 0.5
-}" min-height="100" class="fill-height">
+      <v-lazy :options="{ threshold: 0.5 }" min-height="100" class="fill-height">
         <v-sheet rounded class="fill-height">
-          <v-container class="pa-0 fill-height">
+          <v-container class="pa-0">
             <v-row no-gutters>
               <v-col cols="12" class="item-panel pa-0 pb-2">
                 <v-img :src="item.image512pxLink" :lazy-src="item.baseImageLink" :class="itemImageClasses">
@@ -249,6 +246,7 @@ const itemImageClasses = computed(() => {
     'elevation-2': true,
     'item-image': true,
     'pa-1': true,
+    'fill-height': true,
   }
 })
 


### PR DESCRIPTION
Changes:
- Full height for item cards and their images

Before:
<img width="588" alt="Screenshot 2023-04-16 at 5 57 42" src="https://user-images.githubusercontent.com/15357910/232252860-6c839260-726e-4203-be40-f2e4a946b555.png">

After:
<img width="586" alt="Screenshot 2023-04-16 at 5 57 50" src="https://user-images.githubusercontent.com/15357910/232252864-9a1167d0-a07d-4e05-bb58-0499dd22a6e6.png">
