### PR TITLE
[Feature] Add wiki link to map card and scroll to task when task name is clicked

### DIFF
--- a/tarkov-tracker/src/components/MapMarker.vue
+++ b/tarkov-tracker/src/components/MapMarker.vue
@@ -12,7 +12,7 @@
   </div>
   <div v-if="tooltipVisible" :style="tooltipStyle">
     <v-sheet class="ma-0 elevation-3 rounded px-1 pt-2" color="primary">
-      <task-link :task="relatedTask" />
+      <task-link :task="relatedTask" show-wiki-link />
       <task-objective
         v-if="props.mark.objectiveId"
         :objective="objectives.find((obj) => obj.id == props.mark.objectiveId)"

--- a/tarkov-tracker/src/components/tasks/TaskCard.vue
+++ b/tarkov-tracker/src/components/tasks/TaskCard.vue
@@ -1,5 +1,6 @@
 <template>
   <v-sheet
+    :id="`task-${props.task.id}`"
     class="pa-2 taskContainer"
     :rounded="true"
     :class="{

--- a/tarkov-tracker/src/components/tasks/TaskLink.vue
+++ b/tarkov-tracker/src/components/tasks/TaskLink.vue
@@ -1,6 +1,6 @@
 <template>
-  <router-link to="/">
-    <div class="d-flex">
+  <div class="d-flex justify-space-between align-center">
+    <router-link to="#" @click.prevent="scrollToTask">
       <v-avatar size="1.5em" style="vertical-align: middle">
         <v-img :src="traderAvatar" />
       </v-avatar>
@@ -17,8 +17,23 @@
       <span class="ml-2 font-weight-bold">
         {{ props.task?.name }}
       </span>
-    </div>
-  </router-link>
+    </router-link>
+    <a
+      v-if="props.showWikiLink"
+      :href="props.task.wikiLink"
+      target="_blank"
+      class="wiki-link"
+    >
+      <v-row no-gutters>
+        <v-col cols="auto" class="mr-1">
+          <v-icon icon="mdi-information-outline" />
+        </v-col>
+        <v-col>
+          {{ $t("page.tasks.questcard.wiki") }}
+        </v-col>
+      </v-row>
+    </a>
+  </div>
 </template>
 <script setup>
 import { computed } from "vue";
@@ -28,6 +43,11 @@ const props = defineProps({
   task: {
     type: Object,
     required: true,
+  },
+  showWikiLink: {
+    type: Boolean,
+    required: false,
+    default: false,
   },
 });
 
@@ -45,6 +65,13 @@ const factionImage = computed(() => {
 const traderAvatar = computed(() => {
   return `/img/traders/${props.task?.trader?.id}.jpg`;
 });
+
+const scrollToTask = () => {
+  const taskCard = document.getElementById(`task-${props.task.id}`);
+  taskCard?.scrollIntoView({
+    block: "center",
+  });
+};
 </script>
 <style lang="scss" scoped>
 a:any-link {
@@ -56,5 +83,10 @@ a:any-link {
   filter: invert(1);
   max-width: 24px;
   max-height: 24px;
+}
+
+.wiki-link {
+  font-size: 12px;
+  white-space: nowrap;
 }
 </style>


### PR DESCRIPTION
# Problem

Navigating between the map, the task cards, and the wiki feels a bit cumbersome and unintuitive.  
I can't tell you how many times I've clicked on the name of a task on the map expecting to be brought to that task, but instead, I'm redirected to the home page. I then have to go back to the tasks view and find the task in the list before can jump to the wiki to get the info I need.

# Solution

This PR makes two changes for more convenient navigation:
1. `TaskLink`s now scroll the page to their corresponding `TaskCard` if one is present on the page. 
2. `MapMarker`s now include a link to the wiki in their tooltip

Before:
![image](https://github.com/TarkovTracker/TarkovTracker/assets/16705594/083baa89-5803-46dc-8613-479781c63748)

After:
![image](https://github.com/TarkovTracker/TarkovTracker/assets/16705594/86d9e460-8c5d-457a-bb2c-ee6fb91e5097)
