### PR TITLE
Added method to track Lightkeeper progress

### DIFF
--- a/tarkov-tracker/src/components/drawer/DrawerLinks.vue
+++ b/tarkov-tracker/src/components/drawer/DrawerLinks.vue
@@ -12,6 +12,8 @@
     </drawer-item>
     <drawer-item icon="mdi-home" locale-key="hideout" to="/hideout">
     </drawer-item>
+    <drawer-item icon="mdi-lighthouse" locale-key="lightkeeper" to="/lightkeeper">
+    </drawer-item>
     <drawer-item
       v-show="fireuser.loggedIn"
       icon="mdi-account-group"

--- a/tarkov-tracker/src/components/tasks/TaskCard.vue
+++ b/tarkov-tracker/src/components/tasks/TaskCard.vue
@@ -346,6 +346,7 @@
 </template>
 <script setup>
 import { defineAsyncComponent, computed, ref } from "vue";
+import { useRouter } from "vue-router";
 import { useDisplay } from "vuetify";
 import { useTarkovStore } from "@/stores/tarkov.js";
 import { useProgressStore } from "@/stores/progress";
@@ -364,6 +365,7 @@ const tarkovStore = useTarkovStore();
 const progressStore = useProgressStore();
 const userStore = useUserStore();
 const { tasks } = useTarkovData();
+const router = useRouter();
 
 const TaskLink = defineAsyncComponent(() =>
   import("@/components/tasks/TaskLink.vue")
@@ -438,6 +440,11 @@ const uncompletedIrrelevantObjectives = computed(() => {
 });
 
 const onMapView = computed(() => {
+  if (router.currentRoute.value.name == "lightkeeper") {
+    // no need to filter any objectives by current map if we are on the lightkeeper progress page
+    return false;
+  }
+
   // If the primary task view is set to map, then we are on the map page
   return userStore.getTaskPrimaryView == "maps";
 });

--- a/tarkov-tracker/src/locales/de.json5
+++ b/tarkov-tracker/src/locales/de.json5
@@ -101,6 +101,14 @@
         statusdowngraded: " {name} wurde runtergestuft von Stufe {level}",
       },
     },
+    lightkeeper: {
+      title: "Lightkeeper",
+      primaryviews: {
+        all: "Alle",
+        available: "Verfügbar",
+      },
+      total_remaining: "Verbleibende Tasks",
+    },
     neededitems: {
       title: "Zu sammelnde Gegenstände",
       loading: "Lade Aufgaben und Versteckdaten",
@@ -237,6 +245,7 @@
     level: "Level",
     team: "Team",
     tasks: "Aufgaben",
+    lightkeeper: "Lightkeeper",
     hideout: "Versteck",
     neededitems: "benötigte Gegenstände",
     tarkovdev: "Tarkov.dev",
@@ -268,6 +277,10 @@
     hideout: {
       title: "Hideout",
       description: "Du kannst Fortschritt im Hideout auswählen und die benötigten Gegenstände für dein Versteck werden aktualisiert.",
+    },
+    lightkeeper: {
+      title: "Lightkeeper",
+      description: "Diese Seite zeigt den Fortschritt bis zum Freischalten von Lightkeeper. Alle hier aufgelisteten Tasks müssen abgeschlossen werden bevor Lightkeeper im Spiel zur Verfügung steht.",
     },
     neededitems: {
       title: "Zu sammelnde Gegenstände",

--- a/tarkov-tracker/src/locales/en.json5
+++ b/tarkov-tracker/src/locales/en.json5
@@ -102,6 +102,14 @@
         statusdowngraded: "Downgraded {name} from level {level}",
       },
     },
+    lightkeeper: {
+      title: "Lightkeeper",
+      primaryviews: {
+        all: "All",
+        available: "Available",
+      },
+      total_remaining: "Total tasks remaining",
+    },
     neededitems: {
       title: "Needed Items",
       loading: "Loading task and hideout data",
@@ -269,6 +277,7 @@
     level: "Level",
     team: "Team",
     tasks: "Tasks",
+    lightkeeper: "Lightkeeper",
     hideout: "Hideout",
     neededitems: "Needed Items",
     tarkovdev: "Tarkov.dev",
@@ -300,6 +309,10 @@
     hideout: {
       title: "Hideout",
       description: "You can mark off progress towards building and upgrading your hideout. The progress you mark will be used to calculate needed items for your hideout.",
+    },
+    lightkeeper: {
+      title: "Lightkeeper",
+      description: "This page helps you track your current progress towards unlocking the Lightkeeper. All tasks shown must be completed before you can gain access to Lightkeeper.",
     },
     neededitems: {
       title: "Needed Items",

--- a/tarkov-tracker/src/pages/LightKeeper.vue
+++ b/tarkov-tracker/src/pages/LightKeeper.vue
@@ -1,0 +1,168 @@
+<template>
+  <tracker-tip tip="lightkeeper"></tracker-tip>
+
+  <v-container>
+    <v-row justify="center">
+      <v-col lg="4" md="12">
+        <v-card>
+          <v-tabs
+            v-model="activePrimaryView"
+            bg-color="accent"
+            slider-color="secondary"
+            align-tabs="center"
+            show-arrows
+          >
+            <v-tab
+              v-for="(view, index) in primaryViews"
+              :key="index"
+              :value="view.view"
+              :prepend-icon="view.icon"
+            >
+              {{ view.title }}
+            </v-tab>
+          </v-tabs>
+        </v-card>
+      </v-col>
+      <v-col lg="6" md="12">
+        <v-card class="h-100 d-flex align-center pl-4">
+          {{ $t("page.lightkeeper.total_remaining") }}:
+          {{ totalTasksRemaining }}
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+
+  <v-container v-if="loadingTasks || reloadingTasks">
+    <!-- If we're still waiting on tasks from tarkov.dev API -->
+    <v-progress-circular
+      indeterminate
+      color="secondary"
+      class="mx-2"
+    ></v-progress-circular>
+    {{ $t("page.tasks.loading") }}
+    <refresh-button />
+  </v-container>
+  <v-container v-if="!loadingTasks && !reloadingTasks">
+    <v-alert v-if="visibleTasks.length == 0" icon="mdi-clipboard-search">
+      {{ $t("page.tasks.notasksfound") }}
+    </v-alert>
+    <v-lazy
+      v-for="(task, taskIndex) in visibleTasks"
+      :key="taskIndex"
+      :options="{
+        threshold: 0.5,
+      }"
+      min-height="100"
+    >
+      <task-card :task="task" class="my-1" />
+    </v-lazy>
+  </v-container>
+</template>
+<script setup>
+import { defineAsyncComponent, computed, watch, ref, shallowRef } from "vue";
+import { useI18n } from "vue-i18n";
+import { useTarkovData } from "@/composables/tarkovdata";
+import { useProgressStore } from "@/stores/progress";
+
+const TrackerTip = defineAsyncComponent(() =>
+  import("@/components/TrackerTip.vue")
+);
+const TaskCard = defineAsyncComponent(() =>
+  import("@/components/tasks/TaskCard.vue")
+);
+const RefreshButton = defineAsyncComponent(() =>
+  import("@/components/RefreshButton.vue")
+);
+const { t } = useI18n({ useScope: "global" });
+const progressStore = useProgressStore();
+
+const VIEW_ALL = "all";
+const VIEW_AVAILABLE = "available";
+const primaryViews = [
+  {
+    title: t("page.lightkeeper.primaryviews.all"),
+    icon: "mdi-clipboard-check",
+    view: VIEW_ALL,
+  },
+  {
+    title: t("page.lightkeeper.primaryviews.available"),
+    icon: "mdi-clipboard-text",
+    view: VIEW_AVAILABLE,
+  },
+];
+
+const activePrimaryView = ref({});
+
+const { tasks, loading: tasksLoading } = useTarkovData();
+
+const loadingTasks = computed(() => {
+  return tasksLoading.value;
+});
+const reloadingTasks = ref(true);
+
+const visibleTasks = shallowRef([]);
+const totalTasksRemaining = ref(0);
+
+const updateVisibleTasks = async function () {
+  console.log("Tasks updating (" + activePrimaryView.value + ")...");
+
+  let fullTaskList = JSON.parse(JSON.stringify(tasks.value));
+
+  let lightkeeperTasks = [];
+  let numberOfTasksRemaining = 0;
+
+  for (const task of fullTaskList) {
+    if (!task.lightkeeperRequired) {
+      continue;
+    }
+    if (progressStore.tasksCompletions[task.id].self) {
+      continue;
+    }
+
+    // add up all relevant tasks which have not been completed yet
+    numberOfTasksRemaining++;
+
+    if (activePrimaryView.value == VIEW_AVAILABLE) {
+      // if we are showing the available tasks, filter for unlockedTasks
+      if (progressStore.unlockedTasks[task.id].self != true) {
+        continue;
+      }
+    }
+
+    lightkeeperTasks.push(task);
+  }
+
+  lightkeeperTasks.sort(
+    (a, b) => a.predecessors.length - b.predecessors.length
+  );
+
+  /*
+  for (const task of lightkeeperTasks) {
+    console.log("Task:", task, progressStore.unlockedTasks[task.id]);
+  }
+  */
+
+  reloadingTasks.value = false;
+  visibleTasks.value = lightkeeperTasks;
+  totalTasksRemaining.value = numberOfTasksRemaining;
+};
+
+// Watch for changes to the views, and update the visible tasks
+watch(
+  [activePrimaryView, tasks],
+  async () => {
+    reloadingTasks.value = true;
+    await updateVisibleTasks();
+  },
+  { immediate: true }
+);
+
+watch(
+  () => progressStore.tasksCompletions,
+  async () => {
+    reloadingTasks.value = true;
+    await updateVisibleTasks();
+  }
+);
+</script>
+<style lang="scss" scoped></style>

--- a/tarkov-tracker/src/router/routes.js
+++ b/tarkov-tracker/src/router/routes.js
@@ -25,6 +25,12 @@ const routes = [
         component: () => import("@/pages/TaskList.vue"),
       },
       {
+        name: "lightkeeper",
+        path: "/lightkeeper",
+        meta: {},
+        component: () => import("@/pages/LightKeeper.vue"),
+      },
+      {
         name: "hideout",
         path: "/hideout",
         meta: { background: "hideout" },


### PR DESCRIPTION
We'll use the progress store to specifically track which tasks the user still needs to do so that Lighkeeper will be available in game.

The idea behind this feature is the following. Once you reach the mid-30 levels, you have so many tasks open that it gets hard to keep track. Especially if you are working toward a specific goal, like for instance unlocking Lighkeeper. There is only a few tasks that you still need to do, but they are hiding in the huge pool of open tasks.
Therefore this page specifically only shows the tasks needed to complete in order to unlock Lighkeeper. It uses the normal progress store, so by completing tasks as normal, the list gets smaller and smaller until there are no tasks left anymore.