### PR TITLE
Take "hideGlobalTasks" parameter into account

### DIFF
--- a/tarkov-tracker/src/pages/TaskList.vue
+++ b/tarkov-tracker/src/pages/TaskList.vue
@@ -344,6 +344,7 @@ const mapTaskTotals = computed(() => {
             if (objective.maps.includes(map.id)) {
               if (progressStore.objectiveCompletions[objective.id].self !== true) {
                 anyObjectiveLeft=true;
+                break;
               }
             }
           }

--- a/tarkov-tracker/src/pages/TaskList.vue
+++ b/tarkov-tracker/src/pages/TaskList.vue
@@ -328,6 +328,9 @@ const mapTaskTotals = computed(() => {
       if (disabledTasks.includes(task.id)) {
         continue;
       }
+      if (hideGlobalTasks.value && task.map == null) {
+        continue;
+      }
       if (task.locations.includes(map.id)) {
         if (
           (activeUserView.value == "all" &&

--- a/tarkov-tracker/src/pages/TaskList.vue
+++ b/tarkov-tracker/src/pages/TaskList.vue
@@ -339,7 +339,18 @@ const mapTaskTotals = computed(() => {
             )) ||
           progressStore.unlockedTasks[task.id][activeUserView.value]
         ) {
-          mapTaskCounts[map.id]++;
+          let anyObjectiveLeft = false;
+          for (const objective of task.objectives){
+            if (objective.maps.includes(map.id)) {
+              if (progressStore.objectiveCompletions[objective.id].self !== true) {
+                anyObjectiveLeft=true;
+              }
+            }
+          }
+
+          if (anyObjectiveLeft) {
+            mapTaskCounts[map.id]++;
+          }
         }
       }
     }


### PR DESCRIPTION
If the hideGlobalTasks parameter is active, the tasks-per-map counter needs to ignore global tasks. We needs to use the same logic that the task list uses to filter out global tasks. The task list checks the map property of the task object for null.

Resolves #424