### PR TITLE
Fix missing icon for traderStanding objective

### DIFF
--- a/tarkov-tracker/src/components/tasks/TaskObjective.vue
+++ b/tarkov-tracker/src/components/tasks/TaskObjective.vue
@@ -151,6 +151,7 @@ const objectiveIcon = computed(() => {
     mark: "mdi-remote",
     place: "mdi-arrow-down-drop-circle-outline",
     traderLevel: "mdi-thumb-up",
+    traderStanding: "mdi-thumb-up",
     skill: "mdi-dumbbell",
     visit: "mdi-crosshairs-gps",
     buildWeapon: "mdi-progress-wrench",


### PR DESCRIPTION
The Establish Contact task has an objective of type traderStanding which would otherwise display as mdi-help-circle